### PR TITLE
Astropy.io.fits as fallback option when pyfits is not available anymore

### DIFF
--- a/sed/limbdark.py
+++ b/sed/limbdark.py
@@ -112,7 +112,10 @@ Author: Pieter Degroote, with thanks to Steven Bloemen.
 import logging
 import os
 import itertools
-import pyfits
+try:
+    import pyfits as pf
+except:
+    import astropy.io.fits as pf
 import numpy as np
 from scipy.optimize import leastsq,fmin
 from scipy.interpolate import splrep, splev

--- a/sed/model.py
+++ b/sed/model.py
@@ -290,7 +290,10 @@ import sys
 import glob
 import logging
 import copy
-import pyfits
+try:
+    import pyfits as pf
+except:
+    import astropy.io.fits as pf
 import time
 import numpy as np
 try:

--- a/sigproc/interpol.py
+++ b/sigproc/interpol.py
@@ -3,7 +3,10 @@ Non-standard interpolation methods.
 """
 import numpy as np
 from scipy import ndimage
-import pyfits as pf
+try:
+    import pyfits as pf
+except:
+    import astropy.io.fits as pf
 import time
 import itertools
 import pyfinterpol


### PR DESCRIPTION
Pyfits is being integrated in astropy.io.fits and pyfits will not be maintained as a separate package. I have try-excepted the imports to make use of astropy when pyfits is not available.
